### PR TITLE
Update so tests will still pass after refactoring

### DIFF
--- a/spec/ballerina_spec.rb
+++ b/spec/ballerina_spec.rb
@@ -1,15 +1,15 @@
-describe 'Ballerina' do 
+describe 'Ballerina' do
   let(:ballerina) {Ballerina.new('Anna')}
 
   it 'includes the Dance module' do
-    expect(ballerina).to be_a_kind_of(Dance)
+    expect(ballerina).to have_instance_dance_methods
   end
 
   it 'has a name' do
-    expect(ballerina.name).to eq('Anna')  
+    expect(ballerina.name).to eq('Anna')
   end
 
-  it 'extends the MetaDancing module' do 
-    expect(Ballerina).to be_a_kind_of(MetaDancing)
+  it 'extends the MetaDancing module' do
+    expect(Ballerina).to have_class_dance_methods
   end
 end

--- a/spec/kid_spec.rb
+++ b/spec/kid_spec.rb
@@ -1,15 +1,15 @@
-describe 'Kid' do 
+describe 'Kid' do
   let(:kid) {Kid.new("Pat")}
 
   it 'includes the Dance module' do
-    expect(kid).to be_a_kind_of(Dance)
+    expect(kid).to have_instance_dance_methods
   end
 
   it 'has a name' do
-    expect(kid.name).to eq('Pat')  
+    expect(kid.name).to eq('Pat')
   end
 
-  it 'extends the MetaDancing module' do 
-    expect(Kid).to be_a_kind_of(MetaDancing)
+  it 'extends the MetaDancing module' do
+    expect(Kid).to have_class_dance_methods
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,18 @@ require_relative '../lib/dance_module'
 require_relative '../lib/kid'
 require_relative '../lib/fancy_dance.rb'
 
+RSpec::Matchers.define :have_instance_dance_methods do
+  match do |actual|
+    (actual.is_a? FancyDance::InstanceMethods) || (actual.is_a? Dance)
+  end
+end
+
+RSpec::Matchers.define :have_class_dance_methods do
+  match do |actual|
+    (actual.is_a? FancyDance::ClassMethods) || (actual.is_a? MetaDancing)
+  end
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Add custom rspec matchers so there is now one matcher to check to
see if a class includes Dance or FancyDance::InstanceMethods and
one custom matcher to see if a class extends MetaDancing or
FancyDance::ClassMethods.

@PeterBell @AnnJohn 

Closes #25 
